### PR TITLE
add a partial type definition for SparkMD5

### DIFF
--- a/SparkMD5/spark-md5.d.ts
+++ b/SparkMD5/spark-md5.d.ts
@@ -1,5 +1,5 @@
 declare module "spark-md5" {
   export class SparkMD5 {
-    hash: (s: string, raw?: boolean) => string;
+    static hash: (s: string, raw?: boolean) => string;
   }
 }

--- a/SparkMD5/spark-md5.d.ts
+++ b/SparkMD5/spark-md5.d.ts
@@ -1,7 +1,5 @@
 declare module "spark-md5" {
-  class SparkMD5 {
+  export default class SparkMD5 {
     static hash: (s: string, raw?: boolean) => string;
   }
-
-  export = SparkMD5;
 }

--- a/SparkMD5/spark-md5.d.ts
+++ b/SparkMD5/spark-md5.d.ts
@@ -1,5 +1,5 @@
 declare module "spark-md5" {
-  export class SparkMD5 {
+  export default class SparkMD5 {
     static hash: (s: string, raw?: boolean) => string;
   }
 }

--- a/SparkMD5/spark-md5.d.ts
+++ b/SparkMD5/spark-md5.d.ts
@@ -1,0 +1,5 @@
+declare module "spark-md5" {
+  export class SparkMD5 {
+    hash: (s: string, raw?: boolean) => string;
+  }
+}

--- a/SparkMD5/spark-md5.d.ts
+++ b/SparkMD5/spark-md5.d.ts
@@ -1,7 +1,4 @@
 declare module "spark-md5" {
-  class SparkMD5 {
-    static hash: (s: string, raw?: boolean) => string;
-  }
-  
-  export = SparkMD5;
+    // This is a partial type definition and only shows the static method
+    export function hash(value: string, raw?: boolean): string;
 }

--- a/SparkMD5/spark-md5.d.ts
+++ b/SparkMD5/spark-md5.d.ts
@@ -1,5 +1,7 @@
 declare module "spark-md5" {
-  export default class SparkMD5 {
+  class SparkMD5 {
     static hash: (s: string, raw?: boolean) => string;
   }
+
+  export = SparkMD5;
 }

--- a/SparkMD5/spark-md5.d.ts
+++ b/SparkMD5/spark-md5.d.ts
@@ -1,3 +1,8 @@
+// Type definitions for SparkMD5 2.0.2
+// Project: https://github.com/satazor/js-spark-md5
+// Definitions by: sri raghavan <https://github.com/srir>
+// Definitions: https://github.com/Asana/DefinitelyTyped
+
 declare module "spark-md5" {
     // This is a partial type definition and only shows the static method
     export function hash(value: string, raw?: boolean): string;

--- a/SparkMD5/spark-md5.d.ts
+++ b/SparkMD5/spark-md5.d.ts
@@ -1,5 +1,7 @@
 declare module "spark-md5" {
-  export default class SparkMD5 {
+  class SparkMD5 {
     static hash: (s: string, raw?: boolean) => string;
   }
+  
+  export = SparkMD5;
 }


### PR DESCRIPTION
https://github.com/satazor/js-spark-md5 is js source

we're only using the static `hash` method, so only including that here