### PR TITLE
[Quill] id and tabindex

### DIFF
--- a/quill/quill.d.ts
+++ b/quill/quill.d.ts
@@ -126,6 +126,8 @@ declare module "quill" {
             readOnly?: boolean;
             styles?: {};
             theme?: string;
+            id?: string;
+            tabindex?: string;
         }
 
         export interface ThemeClass {


### PR DESCRIPTION
QuillConfig allows the caller to specify `id` and `tabindex`