### PR TITLE
[ReactDnd] change NativeTypes to use string typing

### DIFF
--- a/react-dnd/react-dnd-html5-backend.d.ts
+++ b/react-dnd/react-dnd-html5-backend.d.ts
@@ -6,11 +6,11 @@
 ///<reference path='./react-dnd.d.ts' />
 
 declare module "react-dnd-html5-backend" {
-  export var NativeTypes: {
-    FILE: string,
-    URL: string,
-    TEXT: string
-  };
-  export function getEmptyImage(): any; // Image
-  export default class HTML5Backend implements __ReactDnd.Backend { }
+    export var NativeTypes: {
+        FILE: string,
+        URL: string,
+        TEXT: string
+    };
+    export function getEmptyImage(): any; // Image
+    export default class HTML5Backend implements __ReactDnd.Backend { }
 }

--- a/react-dnd/react-dnd-html5-backend.d.ts
+++ b/react-dnd/react-dnd-html5-backend.d.ts
@@ -6,7 +6,11 @@
 ///<reference path='./react-dnd.d.ts' />
 
 declare module "react-dnd-html5-backend" {
-  export enum NativeTypes { FILE, URL, TEXT }
+  export var NativeTypes: {
+    FILE: string,
+    URL: string,
+    TEXT: string
+  };
   export function getEmptyImage(): any; // Image
   export default class HTML5Backend implements __ReactDnd.Backend { }
 }

--- a/react-dnd/react-dnd-html5-backend.d.ts
+++ b/react-dnd/react-dnd-html5-backend.d.ts
@@ -6,11 +6,11 @@
 ///<reference path='./react-dnd.d.ts' />
 
 declare module "react-dnd-html5-backend" {
-    export var NativeTypes: {
-        FILE: string,
-        URL: string,
-        TEXT: string
-    };
+    export namespace NativeTypes {
+        export const FILE: string;
+        export const URL: string;
+        export const TEXT: string;
+    }
     export function getEmptyImage(): any; // Image
     export default class HTML5Backend implements __ReactDnd.Backend { }
 }

--- a/react-dnd/react-dnd-tests.ts
+++ b/react-dnd/react-dnd-tests.ts
@@ -15,7 +15,7 @@ import DragSource = ReactDnd.DragSource;
 import DropTarget = ReactDnd.DropTarget;
 import DragLayer = ReactDnd.DragLayer;
 import DragDropContext = ReactDnd.DragDropContext;
-import HTML5Backend, { getEmptyImage } from "react-dnd-html5-backend";
+import HTML5Backend, { getEmptyImage, NativeTypes } from "react-dnd-html5-backend";
 import TestBackend from "react-dnd-test-backend";
 
 // Game Component
@@ -201,6 +201,7 @@ module BoardSquare {
     }
 
     export var DndBoardSquare = DropTarget(ItemTypes.KNIGHT, boardSquareTarget, boardSquareCollect)(BoardSquare);
+    export var fileDropTarget = DropTarget(NativeTypes.FILE, boardSquareTarget, boardSquareCollect)(BoardSquare);
     export var create = React.createFactory(DndBoardSquare);
 }
 
@@ -301,3 +302,4 @@ Board.createWithHTMLBackend({
 Board.createWithTestBackend({
     knightPosition: [0, 0]
 });
+

--- a/react-dnd/react-dnd-tests.ts
+++ b/react-dnd/react-dnd-tests.ts
@@ -302,4 +302,3 @@ Board.createWithHTMLBackend({
 Board.createWithTestBackend({
     knightPosition: [0, 0]
 });
-


### PR DESCRIPTION
The NativeTypes exposed by the html5 backend were previously typed as ints through an enum. However these types are meant to be used as drag source types by function such as DragSource() and DropTarget(), which expect string types. This pr changes the NativeTypes declaration to use strings instead of ints. 
